### PR TITLE
add CRON into container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+## Set OUTDIR to your perferred directory!
+## Edit the configuration in the example/ directory to select your sites (optional)
+## Run `make`
+
+.PHONY: example
+HERE=$(shell pwd)
+OUTDIR=/zpool/minio/NOAA_GEFS
+
+example:
+	docker build -t rqthomas/noaa_gefs_download_downscale . 
+	docker run -v $(OUTDIR)/data:/noaa/data -v $(HERE)/example/:/noaa/config rqthomas/noaa_gefs_download_downscale
+

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 
 .PHONY: example
 HERE=$(shell pwd)
-OUTDIR=/zpool/minio/NOAA_GEFS
+OUTDIR=${OUTDIR:=$HERE}
 
 example:
 	docker build -t rqthomas/noaa_gefs_download_downscale . 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,20 @@
 ## NOAA GEFS downloading and temporally (6 hr to 1 hr) downscaling container
 
+## Quickstart
+
+Set the OUTDIR to your preferred output location in the `Makefile`.
+Run: 
+
+```bash
+make
+```
+
+to build the container and start the CRON job to generate data every 6 hrs.  
+
+**Configuration**: 
+- edit `hello-cron` to adjust the cron timing.
+- edit the site configuration in the `example` directory as described below.
+
 ### To run the container
 
 - Pull the container from DockerHub
@@ -27,6 +42,8 @@
   machine and `DIRECTORY_HOST_CONFIG` with your configuration directory
 
 	`docker run -v DIRECTORY_HOST_SHARED:/noaa/data -v DIRECTORY_HOST_CONFIG:/noaa/config rqthomas/noaa_gefs_download_downscale bash /run_noaa_download_downscale.sh`
+
+
 
 ### To run in R (not using container)
 

--- a/hello-cron
+++ b/hello-cron
@@ -1,0 +1,3 @@
+## Run every six hours: (https://crontab.guru/#0_*/6_*_*_*)
+0 */6 * * * /usr/local/bin/Rscript /noaa/launch_download_downscale.R
+

--- a/run_noaa_download_downscale.sh
+++ b/run_noaa_download_downscale.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-Rscript /noaa/launch_download_downscale.R
-


### PR DESCRIPTION
Sets up a cron job inside the container to run the script every 6 hours.

Also updates README.  I like less typing and config-free examples, so I put the docker commands into a Makefile with some defaults, so one can just run `make` and this should execute.  